### PR TITLE
Fix "PIDS: command not found" error

### DIFF
--- a/phosh_renice.sh
+++ b/phosh_renice.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-PIDS = "$(pidof phoc) $(pidof phosh) $(pidof squeekboard) $(pidof calls)"
+PIDS="$(pidof phoc) $(pidof phosh) $(pidof squeekboard) $(pidof calls)"
 renice -n -1 -p $PIDS
 


### PR DESCRIPTION
I am getting 

`bash /usr/local/sbin/phosh_renice: line 3: PIDS: command not found`.

This change fixes the script syntax.